### PR TITLE
Check callback for undefined

### DIFF
--- a/src/Database/PostgreSQL.js
+++ b/src/Database/PostgreSQL.js
@@ -13,7 +13,7 @@ exports.ffiConnect = function(pool) {
         return function(onSuccess) {
             return function() {
                 pool.connect(function(err, client, done) {
-                    if (err !== null) {
+                    if (err != null) {
                         onError(err)();
                         return;
                     }
@@ -35,7 +35,7 @@ exports.ffiUnsafeQuery = function(client) {
                             values: values,
                             rowMode: 'array',
                         }, function(err, result) {
-                            if (err !== null) {
+                            if (err != null) {
                                 onError(err)();
                                 return;
                             }


### PR DESCRIPTION
As of 7.0 pg / 2.0 pg-pool the callback is called with `undefined` rather than `null`: https://github.com/brianc/node-pg-pool/blob/master/index.js#L227