### PR TITLE
Fix `purs bundle` output

### DIFF
--- a/src/Database/PostgreSQL/Value.js
+++ b/src/Database/PostgreSQL/Value.js
@@ -4,8 +4,8 @@
 // value to js Date, so we have
 // to prevent this craziness
 var pg = require('pg');
-var DATE_OID = 1082;
-pg.types.setTypeParser(DATE_OID, function(dateString) { return dateString; });
+
+pg.types.setTypeParser(1082 /* DATE_OID */, function(dateString) { return dateString; });
 
 exports['null'] = null;
 


### PR DESCRIPTION
`purs bundle` (used by e.g. `pulp build`) fails to output `DATE_OID` in the output bundle due to some dead code elimination bug/feature, so an app using `purescript-postgresql-client` fails to start.

Remove `DATE_OID` and use its value inline instead.