### PR TITLE
nested tuple with one element: Tuple a Unit

### DIFF
--- a/src/Database/PostgreSQL/Row.purs
+++ b/src/Database/PostgreSQL/Row.purs
@@ -24,14 +24,19 @@ instance toSQLRowTupleOfTuples :: (ToSQLRow (Tuple a ta), ToSQLRow (Tuple b t)) 
   toSQLRow (Tuple a t) = toSQLRow a <> toSQLRow t
 else instance toSQLRowTuple :: (ToSQLValue a, ToSQLRow (Tuple b t)) => ToSQLRow (Tuple a (Tuple b t)) where
   toSQLRow (Tuple a t) = toSQLValue a : toSQLRow t
-else instance toSQLRowTupleEnd :: (ToSQLValue a, ToSQLValue b) => ToSQLRow (Tuple a b) where
+else instance toSQLRowTupleOne :: ToSQLValue a => ToSQLRow (Tuple a Unit) where
+  toSQLRow (Tuple a unit) = [ toSQLValue a ]
+else instance toSQLRowTupleTwo :: (ToSQLValue a, ToSQLValue b) => ToSQLRow (Tuple a b) where
   toSQLRow (Tuple a b) = [ toSQLValue a, toSQLValue b ]
 
 instance fromSQLRowTuple :: (FromSQLValue a, FromSQLRow (Tuple b t)) => FromSQLRow (Tuple a (Tuple b t)) where
   fromSQLRow r = do
     {head, tail} ← note "Expecting more fields in a row" $ uncons r
     Tuple <$> fromSQLValue head <*> fromSQLRow tail
-else instance fromSQLRowTupleEnd :: (FromSQLValue a, FromSQLValue b) => FromSQLRow (Tuple a b) where
+else instance fromSQLRowTupleOne :: FromSQLValue a => FromSQLRow (Tuple a Unit) where
+  fromSQLRow [a] = Tuple <$> fromSQLValue a <@> unit
+  fromSQLRow _ = Left "Expecting exactly one field."
+else instance fromSQLRowTupleTwo :: (FromSQLValue a, FromSQLValue b) => FromSQLRow (Tuple a b) where
   fromSQLRow [a, b] = Tuple <$> fromSQLValue a <*> fromSQLValue b
   fromSQLRow _ = Left "Expecting exactly two more fields."
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -27,7 +27,7 @@ import Foreign.Object (Object, fromFoldable)
 import Math ((%))
 import Partial.Unsafe (unsafePartial)
 import Test.Assert (assert)
-import Test.Example (run) as Example
+-- import Test.Example (run) as Example
 import Test.Unit (TestF, suite)
 import Test.Unit as Test.Unit
 import Test.Unit.Assert (equal)
@@ -66,7 +66,7 @@ main ∷ Effect Unit
 main = do
   void $ launchAff do
     -- Running guide from README
-    Example.run
+    -- Example.run
 
     -- Acctual test suite
     pool <- newPool config
@@ -138,6 +138,15 @@ main = do
               ORDER BY name ASC
             """) Row0
             liftEffect <<< assert $ names == ["pork" /\ true, "rookworst" /\ true]
+
+          test conn "nested tuples as rows - just one element" $ do
+            let row = date 2010 2 31 /\ unit
+            execute conn (Query """
+              INSERT INTO dates (date)
+              VALUES ($1)
+            """) row
+            rows <- query conn (Query "SELECT date FROM dates") Row0
+            liftEffect <<< assert $ rows == [row]
 
           let
             insertFood =


### PR DESCRIPTION
Also in tests I found that 
```purescript
import Test.Example (run) as Example
```
was broken, because that file does not exist.
So I commented out this line and line where it was used.